### PR TITLE
Address #3: Add endpoint to create new users

### DIFF
--- a/services/dashboard_service/test_dashboard.yml
+++ b/services/dashboard_service/test_dashboard.yml
@@ -100,3 +100,131 @@ steps:
       filename: module1-day1.ipynb
       path: /home/alice/module1-day1.ipynb
     expected_status: 201 CREATED
+---
+name: Create user OK
+patches:
+  "dashboard_service.auth":
+    user_for_token.return_value: '{"name": "tokenuser"}'
+  "dashboard_service.does_user_exist":
+    side_effect: "[False, True]"
+  "dashboard_service.open":
+    return_value: "StringIO()"
+  "dashboard_service.check_call":
+    return_value: "0"
+steps:
+  - method: POST
+    endpoint: /users
+    headers:
+      Authorization: "token testtoken"
+    json:
+      username: testuser
+      password: testpass
+    expected_status: 201 CREATED
+---
+name: Create user when authorization fails
+patches:
+  "dashboard_service.auth":
+    user_for_token.return_value: 'None'
+  "dashboard_service.does_user_exist":
+    side_effect: "[False, True]"
+  "dashboard_service.open":
+    return_value: "StringIO()"
+  "dashboard_service.check_call":
+    return_value: "0"
+steps:
+  - method: POST
+    endpoint: /users
+    headers:
+      Authorization: "token testtoken"
+    json:
+      username: testuser
+      password: testpass
+    expected_status: 401 UNAUTHORIZED
+---
+name: Create user when content is not JSON
+patches:
+  "dashboard_service.auth":
+    user_for_token.return_value: '{"name": "tokenuser"}'
+  "dashboard_service.does_user_exist":
+    side_effect: "[False, True]"
+  "dashboard_service.open":
+    return_value: "StringIO()"
+  "dashboard_service.check_call":
+    return_value: "0"
+steps:
+  - method: POST
+    endpoint: /users
+    headers:
+      Authorization: "token testtoken"
+    query_string:
+      username: testuser
+      password: testpass
+    expected_status: 400 BAD REQUEST
+---
+name: Create user when username is invalid
+patches:
+  "dashboard_service.auth":
+    user_for_token.return_value: '{"name": "tokenuser"}'
+  "dashboard_service.does_user_exist":
+    side_effect: "[False, True]"
+  "dashboard_service.open":
+    return_value: "StringIO()"
+  "dashboard_service.check_call":
+    return_value: "0"
+steps:
+  - method: POST
+    endpoint: /users
+    headers:
+      Authorization: "token testtoken"
+    json:
+      username: 'testuser$'
+      password: testpass
+    expected_status: 400 BAD REQUEST
+---
+name: Create user when password is invalid
+patches:
+  "dashboard_service.auth":
+    user_for_token.return_value: '{"name": "tokenuser"}'
+  "dashboard_service.does_user_exist":
+    side_effect: "[False, True]"
+  "dashboard_service.open":
+    return_value: "StringIO()"
+  "dashboard_service.check_call":
+    return_value: "0"
+steps:
+  - method: POST
+    endpoint: /users
+    headers:
+      Authorization: "token testtoken"
+    json:
+      username: testuser
+      password: 'testpass$'
+    expected_status: 400 BAD REQUEST
+---
+name: Create user when user already exists
+patches:
+  "dashboard_service.auth":
+    user_for_token.return_value: '{"name": "tokenuser"}'
+  "dashboard_service.does_user_exist":
+    side_effect: "[False, True]"
+  "dashboard_service.open":
+    return_value: "StringIO()"
+  "dashboard_service.check_call":
+    return_value: "0"
+steps:
+  - method: POST
+    endpoint: /users
+    headers:
+      Authorization: "token testtoken"
+    json:
+      username: testuser
+      password: testpass
+    expected_status: 201 CREATED
+  - method: POST
+    endpoint: /users
+    headers:
+      Authorization: "token testtoken"
+    json:
+      username: testuser
+      password: testpass
+    expected_status: 400 BAD REQUEST


### PR DESCRIPTION
This commit adds an endpoint to dashboard_service to create new users.
The endpoint is authenticated using HubAuth provided by jupyterhub.
This will use an Authorization header token (in the same way as JupyterHub's
REST API) to authenticate the user. The default setting is to allow
any JupyterHub user, but we can make this more specific (e.g. depending
on token scopes or if the user is an admin on JupyterHub). These extra
changes haven't been implemented in this commit because that would need
additional fiddling around in JupyterHub for a trainer, which we don't
normally do. If that has to be implemented, it should be taken on
separately.

~~TODO: fix tests, add new tests.~~ Done

Note: the single Python file is getting too big with details, maybe we should split it into modules.